### PR TITLE
Add GPT summary pipeline to storytelling demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,4 @@ Using generative AI Data to solve problems.
 ## Live Demos
 - [Retail Review Sentiment](retail_sentiment_demo.html): interactive sentiment analysis for product reviews.
 - [Synthetic Fraud Detection](fraud_demo.html): tweak fraud rates and visualize transactions.
+- [Automated Data Storytelling](automated_data_storytelling_demo.html): pipelines that produce GPT summaries next to interactive charts.

--- a/automated_data_storytelling_demo.html
+++ b/automated_data_storytelling_demo.html
@@ -6,9 +6,12 @@
   <script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>
   <style>
     body {font-family: Arial, sans-serif; margin:40px; background:#f5f6fa;}
-    #chart {width:100%;max-width:700px;height:450px;margin-top:20px;}
     label {font-weight:bold;}
-    #summary {margin-top:20px;padding:10px;background:#fff;border-radius:8px;box-shadow:0 2px 6px rgba(0,0,0,.1);}
+    #visual {display:flex; gap:20px; flex-wrap:wrap; margin-top:20px;}
+    #chart {flex:2 1 60%; min-width:300px; height:450px;}
+    #summaries {flex:1 1 300px; display:flex; flex-direction:column; gap:20px;}
+    #summary, #gptSummary {padding:10px;background:#fff;border-radius:8px;box-shadow:0 2px 6px rgba(0,0,0,.1);}
+    #gptSummary {min-height:120px; white-space:pre-wrap;}
   </style>
 </head>
 <body>
@@ -16,12 +19,19 @@
   <p>Upload a CSV or load the sample dataset to generate narrative summaries beside interactive charts.</p>
   <input type="file" id="fileInput" accept=".csv" />
   <button id="loadSample">Load Sample Dataset</button>
+  <input type="password" id="apiKey" placeholder="OpenAI API Key" style="margin-left:10px;"/>
+  <button id="refreshGPT">Refresh GPT Summary</button>
   <div style="margin-top:20px;">
     <label for="columnSelect">Numeric column:</label>
     <select id="columnSelect"></select>
   </div>
-  <div id="chart"></div>
-  <div id="summary"></div>
+  <div id="visual">
+    <div id="chart"></div>
+    <div id="summaries">
+      <div id="summary"></div>
+      <div id="gptSummary"></div>
+    </div>
+  </div>
 
   <script>
     let dataset = [];
@@ -46,7 +56,7 @@
       });
       if (cols.length) generateStory(cols[0]);
     }
-    function generateStory(column) {
+    async function generateStory(column) {
       const values = dataset.map(r => parseFloat(r[column])).filter(v => !isNaN(v));
       if (!values.length) return;
       const mean = values.reduce((a,b)=>a+b,0)/values.length;
@@ -55,8 +65,42 @@
       const summary = `The average of <strong>${column}</strong> is <strong>${mean.toFixed(2)}</strong> with a range from <strong>${min.toFixed(2)}</strong> to <strong>${max.toFixed(2)}</strong> based on ${values.length} records.`;
       document.getElementById('summary').innerHTML = summary;
       Plotly.newPlot('chart', [{x: values, type:'histogram', marker:{color:'#7c5cff'}}], {margin:{t:30}, xaxis:{title:column}}, {responsive:true});
+      await generateGPTSummary(column, mean, min, max, values.length);
     }
     document.getElementById('columnSelect').addEventListener('change', e => generateStory(e.target.value));
+
+    async function generateGPTSummary(column, mean, min, max, count){
+      const apiKey = document.getElementById('apiKey').value.trim();
+      const target = document.getElementById('gptSummary');
+      if(!apiKey){
+        target.textContent = 'Enter API key to fetch GPT summary.';
+        return;
+      }
+      target.textContent = 'Generating summary...';
+      const prompt = `Provide a short insight about the distribution of ${column} with mean ${mean.toFixed(2)}, min ${min.toFixed(2)}, max ${max.toFixed(2)} from ${count} observations.`;
+      try{
+        const res = await fetch('https://api.openai.com/v1/chat/completions',{
+          method:'POST',
+          headers:{
+            'Content-Type':'application/json',
+            'Authorization':'Bearer '+apiKey
+          },
+          body:JSON.stringify({
+            model:'gpt-3.5-turbo',
+            messages:[{role:'user',content:prompt}],
+            max_tokens:100
+          })
+        });
+        const data = await res.json();
+        target.textContent = data?.choices?.[0]?.message?.content?.trim() || 'No summary generated.';
+      }catch(err){
+        target.textContent = 'Error generating summary.';
+      }
+    }
+    document.getElementById('refreshGPT').addEventListener('click', ()=>{
+      const col = document.getElementById('columnSelect').value;
+      if(col) generateStory(col);
+    });
     document.getElementById('fileInput').addEventListener('change', e => {
       const file = e.target.files[0];
       if (!file) return;


### PR DESCRIPTION
## Summary
- enhance automated data storytelling demo with layout that displays Plotly chart alongside GPT-powered narrative
- allow users to supply OpenAI API key and trigger summary generation
- document new demo in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b2bc40e5f48332af47a0698d9c83c2