### PR TITLE
Add drift controls to synthetic fraud demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@ Using generative AI Data to solve problems.
 
 ## Live Demos
 - [Retail Review Sentiment](retail_sentiment_demo.html): interactive sentiment analysis for product reviews.
-- [Synthetic Fraud Detection](fraud_demo.html): class-balanced samples with controllable drift to stress-test models.
+- [Synthetic Fraud Detection](fraud_demo.html): tweak fraud rates, enforce class balance, and simulate concept drift to stress-test models.

--- a/README.md
+++ b/README.md
@@ -4,3 +4,4 @@ Using generative AI Data to solve problems.
 ## Live Demos
 - [Retail Review Sentiment](retail_sentiment_demo.html): interactive sentiment analysis for product reviews.
 - [Synthetic Fraud Detection](fraud_demo.html): tweak fraud rates, enforce class balance, and simulate concept drift to stress-test models.
+- [Churn Prediction Dashboard](churn_demo.html): explore churn risk with feature insights, SHAP-style visuals, and what-if analysis.

--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@ Using generative AI Data to solve problems.
 
 ## Live Demos
 - [Retail Review Sentiment](retail_sentiment_demo.html): interactive sentiment analysis for product reviews.
-- [Synthetic Fraud Detection](fraud_demo.html): tweak fraud rates and visualize transactions.
+- [Synthetic Fraud Detection](fraud_demo.html): class-balanced samples with controllable drift to stress-test models.

--- a/fraud_demo.html
+++ b/fraud_demo.html
@@ -12,39 +12,60 @@
 </head>
 <body>
   <h1>Synthetic Fraud Detection Demo</h1>
-  <p>Adjust the slider to change the percentage of fraudulent transactions in the synthetic dataset.</p>
-  <label for="rate">Fraud percentage: <span id="lblRate">5</span>%</label>
-  <input type="range" id="rate" min="1" max="20" value="5" />
+  <p>Use the controls to explore fraud rates, enforce class balance, and simulate concept drift.</p>
+  <div style="margin-top:10px;">
+    <label><input type="checkbox" id="balanced" /> Class-balanced</label>
+  </div>
+  <div style="margin-top:10px;">
+    <label for="rate">Fraud percentage: <span id="lblRate">5</span>%</label>
+    <input type="range" id="rate" min="1" max="50" value="5" />
+  </div>
+  <div style="margin-top:10px;">
+    <label for="drift">Drift level: <span id="lblDrift">0</span></label>
+    <input type="range" id="drift" min="0" max="40" value="0" />
+  </div>
   <div id="chart"></div>
   <script>
-    function generateData(fraudPct) {
+    function generateData(fraudPct, drift) {
       const total = 1000;
       const fraudCount = Math.round(total * fraudPct / 100);
       const legitCount = total - fraudCount;
       const legitX = [], legitY = [], fraudX = [], fraudY = [];
       for (let i = 0; i < legitCount; i++) {
-        legitX.push(Math.random() * 100);
-        legitY.push(Math.random() * 100);
+        legitX.push(Math.random() * 50 + drift);
+        legitY.push(Math.random() * 50 + drift);
       }
       for (let i = 0; i < fraudCount; i++) {
-        fraudX.push(70 + Math.random() * 30); // higher amounts
-        fraudY.push(70 + Math.random() * 30); // later times
+        fraudX.push(70 + Math.random() * 30);
+        fraudY.push(70 + Math.random() * 30);
       }
       const traceLegit = {x: legitX, y: legitY, mode:'markers', name:'Legit', marker:{color:'rgba(0,123,255,0.7)'}};
       const traceFraud = {x: fraudX, y: fraudY, mode:'markers', name:'Fraud', marker:{color:'rgba(220,53,69,0.8)'}};
       Plotly.newPlot('chart', [traceLegit, traceFraud], {
         xaxis:{title:'Transaction Amount'},
         yaxis:{title:'Transaction Time'},
-        margin:{t:30}
+        margin:{t:30},
       }, {responsive:true});
     }
-    const slider = document.getElementById('rate');
-    const label = document.getElementById('lblRate');
-    slider.addEventListener('input', () => {
-      label.textContent = slider.value;
-      generateData(parseInt(slider.value));
-    });
-    generateData(parseInt(slider.value));
+    const rate = document.getElementById('rate');
+    const drift = document.getElementById('drift');
+    const lblRate = document.getElementById('lblRate');
+    const lblDrift = document.getElementById('lblDrift');
+    const balanced = document.getElementById('balanced');
+
+    function update() {
+      const pct = balanced.checked ? 50 : parseInt(rate.value);
+      const driftVal = parseInt(drift.value);
+      lblRate.textContent = pct;
+      lblDrift.textContent = driftVal;
+      rate.disabled = balanced.checked;
+      generateData(pct, driftVal);
+    }
+
+    rate.addEventListener('input', update);
+    drift.addEventListener('input', update);
+    balanced.addEventListener('change', update);
+    update();
   </script>
 </body>
 </html>

--- a/fraud_demo.html
+++ b/fraud_demo.html
@@ -26,14 +26,14 @@
   </div>
   <div id="chart"></div>
   <script>
-    function generateData(fraudPct, drift) {
+    function generateData(fraudPct, driftLevel) {
       const total = 1000;
       const fraudCount = Math.round(total * fraudPct / 100);
       const legitCount = total - fraudCount;
       const legitX = [], legitY = [], fraudX = [], fraudY = [];
       for (let i = 0; i < legitCount; i++) {
-        legitX.push(Math.random() * 50 + drift);
-        legitY.push(Math.random() * 50 + drift);
+        legitX.push(Math.random() * 50 + driftLevel);
+        legitY.push(Math.random() * 50 + driftLevel);
       }
       for (let i = 0; i < fraudCount; i++) {
         fraudX.push(70 + Math.random() * 30);
@@ -47,24 +47,24 @@
         margin:{t:30},
       }, {responsive:true});
     }
-    const rate = document.getElementById('rate');
-    const drift = document.getElementById('drift');
+    const rateSlider = document.getElementById('rate');
+    const driftSlider = document.getElementById('drift');
     const lblRate = document.getElementById('lblRate');
     const lblDrift = document.getElementById('lblDrift');
-    const balanced = document.getElementById('balanced');
+    const balanceToggle = document.getElementById('balanced');
 
     function update() {
-      const pct = balanced.checked ? 50 : parseInt(rate.value);
-      const driftVal = parseInt(drift.value);
+      const pct = balanceToggle.checked ? 50 : parseInt(rateSlider.value);
+      const driftVal = parseInt(driftSlider.value);
       lblRate.textContent = pct;
       lblDrift.textContent = driftVal;
-      rate.disabled = balanced.checked;
+      rateSlider.disabled = balanceToggle.checked;
       generateData(pct, driftVal);
     }
 
-    rate.addEventListener('input', update);
-    drift.addEventListener('input', update);
-    balanced.addEventListener('change', update);
+    rateSlider.addEventListener('input', update);
+    driftSlider.addEventListener('input', update);
+    balanceToggle.addEventListener('change', update);
     update();
   </script>
 </body>


### PR DESCRIPTION
## Summary
- Add class-balance checkbox and drift slider to fraud demo for interactive stress testing
- Document new capabilities in README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b2bc50a6bc8332919cb8a65de8de4e