### PR TITLE
Add SVG fraud detection illustration

### DIFF
--- a/fraud_demo.html
+++ b/fraud_demo.html
@@ -12,6 +12,7 @@
 </head>
 <body>
   <h1>Synthetic Fraud Detection Demo</h1>
+    <img src="images/fraud_detection.svg" alt="Synthetic Data for Fraud Detection" style="max-width:100%;height:auto;">
   <p>Adjust the slider to change the percentage of fraudulent transactions in the synthetic dataset.</p>
   <label for="rate">Fraud percentage: <span id="lblRate">5</span>%</label>
   <input type="range" id="rate" min="1" max="20" value="5" />

--- a/images/fraud_detection.svg
+++ b/images/fraud_detection.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 80">
+  <rect width="120" height="80" fill="#f5f6fa"/>
+  <circle cx="40" cy="40" r="25" fill="#dc3545"/>
+  <rect x="70" y="20" width="30" height="40" fill="#007bff"/>
+  <text x="40" y="47" text-anchor="middle" font-size="32" fill="#fff">!</text>
+</svg>


### PR DESCRIPTION
## Summary
- Replace binary fraud detection image with text-based SVG
- Embed new SVG illustration in `fraud_demo.html`

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b2bb708f008332adc667e70afc6a44